### PR TITLE
Vacuum gripper support

### DIFF
--- a/examples/vacuum_object.py
+++ b/examples/vacuum_object.py
@@ -1,0 +1,57 @@
+"""
+Uses a vacuum gripper to pick up an object, then drops it.
+"""
+import sys
+import time
+from datetime import timedelta
+
+import panda_py
+import panda_py.libfranka
+
+if __name__=='__main__':
+    if len(sys.argv) < 2:
+        raise RuntimeError(f'Usage: python {sys.argv[0]} <robot-hostname>')
+
+    # Connect to the gripper using the same IP as the robot arm
+    # This doesn't prevent you from connecting to the arm
+    gripper=panda_py.libfranka.VacuumGripper(sys.argv[1])
+
+    try:
+        # Print gripper state.
+        state=gripper.read_once()
+        print(f"""Gripper State:
+        is vacuum within setpoint: {state.in_control_range}
+        part detached: {state.part_detached}
+        part present: {state.part_present}
+        device status: {state.device_status}
+        actual power: {state.actual_power}
+        vacuum: {state.vacuum}""")
+        
+        print("Vacuuming object")
+        # The first argument is the vacuum pressure level
+        # The second argument is how long to try vacuuming for before giving an error
+        try:
+            gripper.vacuum(3, timedelta(seconds=1))
+            print("Grabbed object.")
+        except:
+            # The finally block at the end stops the vacuuming with gripper.stop()
+            # otherwise it keeps going
+            raise RuntimeError("Failed to grab object.")
+            
+        time.sleep(3)
+        # Check if the object is still grasped
+        # This works by checking if the pressure level of the vacuum
+        # is within a specified range
+        state=gripper.read_once()
+        if not state.in_control_range:
+            raise RuntimeError("Object lost.")
+        
+        print("Releasing object.")
+        # The time argument specifies when to time-out.
+        try:
+            gripper.drop_off(timedelta(seconds=1))
+        except:
+            raise RuntimeError("Failed to drop object off.")
+    finally:
+        # Stop whatever the gripper is doing when program terminates.
+        gripper.stop()

--- a/src/libfranka.cpp
+++ b/src/libfranka.cpp
@@ -452,39 +452,39 @@ PYBIND11_MODULE(libfranka, m) {
       .def("read_once", &franka::Gripper::readOnce);
 
   py::enum_<franka::VacuumGripperDeviceStatus>(m, "VacuumGripperDeviceStatus")
-	.value("kGreen", franka::VacuumGripperDeviceStatus::kGreen)
-	.value("kYellow", franka::VacuumGripperDeviceStatus::kYellow)
-	.value("kOrange", franka::VacuumGripperDeviceStatus::kOrange)
-	.value("kRed", franka::VacuumGripperDeviceStatus::kRed);
+	  .value("kGreen", franka::VacuumGripperDeviceStatus::kGreen)
+	  .value("kYellow", franka::VacuumGripperDeviceStatus::kYellow)
+	  .value("kOrange", franka::VacuumGripperDeviceStatus::kOrange)
+	  .value("kRed", franka::VacuumGripperDeviceStatus::kRed);
   
   py::class_<franka::VacuumGripperState>(m, "VacuumGripperState")
-	.def_readonly("in_control_range", &franka::VacuumGripperState::in_control_range)
-	.def_readonly("part_detached", &franka::VacuumGripperState::part_detached)
-	.def_readonly("part_present", &franka::VacuumGripperState::part_present)
-	.def_readonly("device_status", &franka::VacuumGripperState::device_status)
-	.def_readonly("actual_power", &franka::VacuumGripperState::actual_power)
-	.def_readonly("vacuum", &franka::VacuumGripperState::vacuum)
-	.def_readonly("time", &franka::VacuumGripperState::time);
-
+	  .def_readonly("in_control_range", &franka::VacuumGripperState::in_control_range)
+	  .def_readonly("part_detached", &franka::VacuumGripperState::part_detached)
+	  .def_readonly("part_present", &franka::VacuumGripperState::part_present)
+	  .def_readonly("device_status", &franka::VacuumGripperState::device_status)
+	  .def_readonly("actual_power", &franka::VacuumGripperState::actual_power)
+	  .def_readonly("vacuum", &franka::VacuumGripperState::vacuum)
+	  .def_readonly("time", &franka::VacuumGripperState::time);
+  
   py::enum_<franka::VacuumGripper::ProductionSetupProfile>(m, "VacuumGripperProductionSetupProfile")
-	.value("kP0", franka::VacuumGripper::ProductionSetupProfile::kP0)
-	.value("kP1", franka::VacuumGripper::ProductionSetupProfile::kP1)
-	.value("kP2", franka::VacuumGripper::ProductionSetupProfile::kP2)
-	.value("kP3", franka::VacuumGripper::ProductionSetupProfile::kP3);
+	  .value("kP0", franka::VacuumGripper::ProductionSetupProfile::kP0)
+	  .value("kP1", franka::VacuumGripper::ProductionSetupProfile::kP1)
+	  .value("kP2", franka::VacuumGripper::ProductionSetupProfile::kP2)
+	  .value("kP3", franka::VacuumGripper::ProductionSetupProfile::kP3);
   
   py::class_<franka::VacuumGripper>(m, "VacuumGripper")
 	.def(py::init<std::string>(), py::arg("franka_address"))
-	.def("server_version", &franka::VacuumGripper::serverVersion)
-	.def("vacuum", &franka::VacuumGripper::vacuum,
-		 py::call_guard<py::gil_scoped_release>(), py::arg("vacuum"),
+	  .def("server_version", &franka::VacuumGripper::serverVersion)
+	  .def("vacuum", &franka::VacuumGripper::vacuum,
+		   py::call_guard<py::gil_scoped_release>(), py::arg("vacuum"),
 		 py::arg("timeout"), 
-		 py::arg("profile") = franka::VacuumGripper::ProductionSetupProfile::kP0)
-	.def("drop_off", &franka::VacuumGripper::dropOff,
-		 py::call_guard<py::gil_scoped_release>(), py::arg("timeout"))
-	.def("stop", &franka::VacuumGripper::stop,
-		 py::call_guard<py::gil_scoped_release>())
-	.def("read_once", &franka::VacuumGripper::readOnce);		 
-	
+		   py::arg("profile") = franka::VacuumGripper::ProductionSetupProfile::kP0)
+	  .def("drop_off", &franka::VacuumGripper::dropOff,
+		   py::call_guard<py::gil_scoped_release>(), py::arg("timeout"))
+	  .def("stop", &franka::VacuumGripper::stop,
+		   py::call_guard<py::gil_scoped_release>())
+	  .def("read_once", &franka::VacuumGripper::readOnce);		 
+  
   m.def("is_valid_elbow", &franka::isValidElbow, py::arg("elbow"));
   m.def("is_homogeneous_transformation", &franka::isHomogeneousTransformation,
         py::arg("transform"));
@@ -492,7 +492,7 @@ PYBIND11_MODULE(libfranka, m) {
   m.def("set_current_thread_to_highest_scheduler_priority",
         &franka::setCurrentThreadToHighestSchedulerPriority,
         py::arg("error_message"));
-
+  
   m.def("motion_finished",
         py::overload_cast<franka::Torques>(&franka::MotionFinished),
         py::arg("command"));

--- a/src/libfranka.cpp
+++ b/src/libfranka.cpp
@@ -1,5 +1,6 @@
 #include <franka/control_tools.h>
 #include <franka/gripper.h>
+#include <franka/vacuum_gripper.h>
 #include <franka/model.h>
 #include <franka/rate_limiting.h>
 #include <franka/robot.h>
@@ -450,6 +451,40 @@ PYBIND11_MODULE(libfranka, m) {
            py::call_guard<py::gil_scoped_release>())
       .def("read_once", &franka::Gripper::readOnce);
 
+  py::enum_<franka::VacuumGripperDeviceStatus>(m, "VacuumGripperDeviceStatus")
+	.value("kGreen", &franka::VacuumGripperDeviceStatus::kGreen)
+	.value("kYellow", &franka::VacuumGripperDeviceStatus::kYellow)
+	.value("kOrange", &franka::VacuumGripperDeviceStatus::kOrange)
+	.value("kRed", &franka::VacuumGripperDeviceStatus::kRed);
+  
+  py::class_<franka::VacuumGripperState>(m, "VacuumGripperState")
+	.def_readonly("in_control_range", &franka::VacuumGripperState::in_control_range)
+	.def_readonly("part_detached", &franka::VacuumGripperState::part_detached)
+	.def_readonly("part_present", &franka::VacuumGripperState::part_present)
+	.def_readonly("device_status", &franka::VacuumGripperState::device_status)
+	.def_readonly("actual_power", &franka::VacuumGripperState::actual_power)
+	.def_readonly("vacuum", &franka::VacuumGripperState::vacuum)
+	.def_readonly("time", &franka::VacuumGripperState::time);
+
+  py::enum_<franka::VacuumGripper::ProductionSetupProfile>(m, "VacuumGripperProductionSetupProfile")
+	.value("kP0", &franka::VacuumGripper::ProductionSetupProfile::kP0)
+	.value("kP1", &franka::VacuumGripper::ProductionSetupProfile::kP1)
+	.value("kP2", &franka::VacuumGripper::ProductionSetupProfile::kP2)
+	.value("kP3", &franka::VacuumGripper::ProductionSetupProfile::kP3);
+  
+  py::class_<franka::VacuumGripper>(m, "VacuumGripper")
+	.def(py::init<std::string>(), py::arg("franka_address"))
+	.def("server_version", &franka::VacuumGripper::serverVersion)
+	.def("vacuum", &franka::VacuumGripper::vacuum,
+		 py::call_guard<py::gil_scoped_release>(), py::arg("vacuum"),
+		 py::arg("timeout"), 
+		 py::arg("profile") = franka::VacuumGripper::ProductionSetupProfile::kP0))
+	.def("drop_off", &franka::VacuumGripper::dropOff,
+		 py::call_guard<py::gil_scoped_release>(), py::arg("timeout"))
+	.def("stop", &franka::VacuumGripper::stop,
+		 py::call_guard<py::gil_scoped_release>())
+	.def("read_once", &franka::VacuumGripper::readOnce);		 
+	
   m.def("is_valid_elbow", &franka::isValidElbow, py::arg("elbow"));
   m.def("is_homogeneous_transformation", &franka::isHomogeneousTransformation,
         py::arg("transform"));

--- a/src/libfranka.cpp
+++ b/src/libfranka.cpp
@@ -452,10 +452,10 @@ PYBIND11_MODULE(libfranka, m) {
       .def("read_once", &franka::Gripper::readOnce);
 
   py::enum_<franka::VacuumGripperDeviceStatus>(m, "VacuumGripperDeviceStatus")
-	.value("kGreen", &franka::VacuumGripperDeviceStatus::kGreen)
-	.value("kYellow", &franka::VacuumGripperDeviceStatus::kYellow)
-	.value("kOrange", &franka::VacuumGripperDeviceStatus::kOrange)
-	.value("kRed", &franka::VacuumGripperDeviceStatus::kRed);
+	.value("kGreen", franka::VacuumGripperDeviceStatus::kGreen)
+	.value("kYellow", franka::VacuumGripperDeviceStatus::kYellow)
+	.value("kOrange", franka::VacuumGripperDeviceStatus::kOrange)
+	.value("kRed", franka::VacuumGripperDeviceStatus::kRed);
   
   py::class_<franka::VacuumGripperState>(m, "VacuumGripperState")
 	.def_readonly("in_control_range", &franka::VacuumGripperState::in_control_range)
@@ -467,10 +467,10 @@ PYBIND11_MODULE(libfranka, m) {
 	.def_readonly("time", &franka::VacuumGripperState::time);
 
   py::enum_<franka::VacuumGripper::ProductionSetupProfile>(m, "VacuumGripperProductionSetupProfile")
-	.value("kP0", &franka::VacuumGripper::ProductionSetupProfile::kP0)
-	.value("kP1", &franka::VacuumGripper::ProductionSetupProfile::kP1)
-	.value("kP2", &franka::VacuumGripper::ProductionSetupProfile::kP2)
-	.value("kP3", &franka::VacuumGripper::ProductionSetupProfile::kP3);
+	.value("kP0", franka::VacuumGripper::ProductionSetupProfile::kP0)
+	.value("kP1", franka::VacuumGripper::ProductionSetupProfile::kP1)
+	.value("kP2", franka::VacuumGripper::ProductionSetupProfile::kP2)
+	.value("kP3", franka::VacuumGripper::ProductionSetupProfile::kP3);
   
   py::class_<franka::VacuumGripper>(m, "VacuumGripper")
 	.def(py::init<std::string>(), py::arg("franka_address"))

--- a/src/libfranka.cpp
+++ b/src/libfranka.cpp
@@ -452,38 +452,38 @@ PYBIND11_MODULE(libfranka, m) {
       .def("read_once", &franka::Gripper::readOnce);
 
   py::enum_<franka::VacuumGripperDeviceStatus>(m, "VacuumGripperDeviceStatus")
-	  .value("kGreen", franka::VacuumGripperDeviceStatus::kGreen)
-	  .value("kYellow", franka::VacuumGripperDeviceStatus::kYellow)
-	  .value("kOrange", franka::VacuumGripperDeviceStatus::kOrange)
-	  .value("kRed", franka::VacuumGripperDeviceStatus::kRed);
+      .value("kGreen", franka::VacuumGripperDeviceStatus::kGreen)
+      .value("kYellow", franka::VacuumGripperDeviceStatus::kYellow)
+      .value("kOrange", franka::VacuumGripperDeviceStatus::kOrange)
+      .value("kRed", franka::VacuumGripperDeviceStatus::kRed);
   
   py::class_<franka::VacuumGripperState>(m, "VacuumGripperState")
-	  .def_readonly("in_control_range", &franka::VacuumGripperState::in_control_range)
-	  .def_readonly("part_detached", &franka::VacuumGripperState::part_detached)
-	  .def_readonly("part_present", &franka::VacuumGripperState::part_present)
-	  .def_readonly("device_status", &franka::VacuumGripperState::device_status)
-	  .def_readonly("actual_power", &franka::VacuumGripperState::actual_power)
-	  .def_readonly("vacuum", &franka::VacuumGripperState::vacuum)
-	  .def_readonly("time", &franka::VacuumGripperState::time);
+      .def_readonly("in_control_range", &franka::VacuumGripperState::in_control_range)
+      .def_readonly("part_detached", &franka::VacuumGripperState::part_detached)
+      .def_readonly("part_present", &franka::VacuumGripperState::part_present)
+      .def_readonly("device_status", &franka::VacuumGripperState::device_status)
+      .def_readonly("actual_power", &franka::VacuumGripperState::actual_power)
+      .def_readonly("vacuum", &franka::VacuumGripperState::vacuum)
+      .def_readonly("time", &franka::VacuumGripperState::time);
   
   py::enum_<franka::VacuumGripper::ProductionSetupProfile>(m, "VacuumGripperProductionSetupProfile")
-	  .value("kP0", franka::VacuumGripper::ProductionSetupProfile::kP0)
-	  .value("kP1", franka::VacuumGripper::ProductionSetupProfile::kP1)
-	  .value("kP2", franka::VacuumGripper::ProductionSetupProfile::kP2)
-	  .value("kP3", franka::VacuumGripper::ProductionSetupProfile::kP3);
+      .value("kP0", franka::VacuumGripper::ProductionSetupProfile::kP0)
+      .value("kP1", franka::VacuumGripper::ProductionSetupProfile::kP1)
+      .value("kP2", franka::VacuumGripper::ProductionSetupProfile::kP2)
+      .value("kP3", franka::VacuumGripper::ProductionSetupProfile::kP3);
   
   py::class_<franka::VacuumGripper>(m, "VacuumGripper")
-	.def(py::init<std::string>(), py::arg("franka_address"))
-	  .def("server_version", &franka::VacuumGripper::serverVersion)
-	  .def("vacuum", &franka::VacuumGripper::vacuum,
-		   py::call_guard<py::gil_scoped_release>(), py::arg("vacuum"),
-		 py::arg("timeout"), 
-		   py::arg("profile") = franka::VacuumGripper::ProductionSetupProfile::kP0)
-	  .def("drop_off", &franka::VacuumGripper::dropOff,
-		   py::call_guard<py::gil_scoped_release>(), py::arg("timeout"))
-	  .def("stop", &franka::VacuumGripper::stop,
-		   py::call_guard<py::gil_scoped_release>())
-	  .def("read_once", &franka::VacuumGripper::readOnce);		 
+    .def(py::init<std::string>(), py::arg("franka_address"))
+      .def("server_version", &franka::VacuumGripper::serverVersion)
+      .def("vacuum", &franka::VacuumGripper::vacuum,
+           py::call_guard<py::gil_scoped_release>(), py::arg("vacuum"),
+         py::arg("timeout"), 
+           py::arg("profile") = franka::VacuumGripper::ProductionSetupProfile::kP0)
+      .def("drop_off", &franka::VacuumGripper::dropOff,
+           py::call_guard<py::gil_scoped_release>(), py::arg("timeout"))
+      .def("stop", &franka::VacuumGripper::stop,
+           py::call_guard<py::gil_scoped_release>())
+      .def("read_once", &franka::VacuumGripper::readOnce);       
   
   m.def("is_valid_elbow", &franka::isValidElbow, py::arg("elbow"));
   m.def("is_homogeneous_transformation", &franka::isHomogeneousTransformation,

--- a/src/libfranka.cpp
+++ b/src/libfranka.cpp
@@ -478,7 +478,7 @@ PYBIND11_MODULE(libfranka, m) {
 	.def("vacuum", &franka::VacuumGripper::vacuum,
 		 py::call_guard<py::gil_scoped_release>(), py::arg("vacuum"),
 		 py::arg("timeout"), 
-		 py::arg("profile") = franka::VacuumGripper::ProductionSetupProfile::kP0))
+		 py::arg("profile") = franka::VacuumGripper::ProductionSetupProfile::kP0)
 	.def("drop_off", &franka::VacuumGripper::dropOff,
 		 py::call_guard<py::gil_scoped_release>(), py::arg("timeout"))
 	.def("stop", &franka::VacuumGripper::stop,


### PR DESCRIPTION
This PR ports over the functionality for controlling vacuum grippers in `libfranka/vacuum_gripper.h`. (documentation here: https://frankaemika.github.io/libfranka/classfranka_1_1VacuumGripper.html)

I tested the `vacuum`, `drop_off`, `read_once` and `stop` functions on a Panda arm with a vacuum gripper (libfranka 0.8.0, Schmalz gripper) and they seem to be working. The functions already present in this library (that bind to `libfranka/gripper.h`) do not work with vacuum grippers.

Please let me know if anything else needs to be done for a merge.