### PR TITLE
fix: make vacuum gripper optional

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,12 +5,15 @@ on:
 
 jobs:
   build_wheels:
-    name: Build all wheels with cibuildwheel
+    name: Build wheels for libfranka  ${{ matrix.libfranka-version }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        libfranka-version: ["0.7.1", "0.8.0", "0.9.2", "0.10.0", "0.11.0", "0.12.1", "0.13.2"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.16.2
       - name: Build all wheels
-        run: ./bin/build_all.sh
+        run: ./bin/build.sh "${{ matrix.libfranka-version }}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,11 @@ set (CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE "Release")
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 
+option(VACUUM_GRIPPER OFF)
+if (VACUUM_GRIPPER)
+  add_definitions(-DVACUUM_GRIPPER=${VACUUM_GRIPPER})
+endif()
+
 find_package(Eigen3 REQUIRED)
 find_package(Threads REQUIRED)
 find_package(Franka REQUIRED)

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Check if the libfranka version is provided as an argument
+if [ -z "$1" ]; then
+    echo "Usage: $0 <libfranka_version>"
+    exit 1
+fi
+
 # Install Python dependencies
 python -m pip install packaging toml cibuildwheel
 
@@ -47,16 +53,14 @@ END
 
 mkdir $root/archive
 
-# Build wheels for common libfranka versions
-libfranka=("0.7.1" "0.8.0" "0.9.2" "0.10.0" "0.11.0" "0.12.1" "0.13.2")
-for value in "${libfranka[@]}"; do
-  echo "Changing libfranka version in pyproject.toml to: $value"
-  change_version "$value"
-  export LIBFRANKA_VER=$value
-  archive=panda_py_${version}_libfranka_${value}
-  python -m cibuildwheel --platform linux --output-dir $root/archive/$archive $root
-  zip -j $root/archive/$archive.zip $root/archive/$archive/*.whl
-done
+# Call the change_version function with the provided libfranka version
+libfranka_version="$1"
+echo "Changing libfranka version in pyproject.toml to: $libfranka_version"
+change_version "$libfranka_version"
+export LIBFRANKA_VER=$libfranka_version
+archive=panda_py_${version}_libfranka_${libfranka_version}
+python -m cibuildwheel --output-dir $root/archive/$archive $root
+zip -j $root/archive/$archive.zip $root/archive/$archive/*.whl
 
 # Change back to default version
-change_version "LIBFRANKA_VER=0.9.2"
+change_version $version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,3 +60,6 @@ build-type = "Release"
 
 [tool.scikit-build.wheel]
 packages = ["src/panda_py"]
+
+[tool.scikit-build.cmake.define]
+VACUUM_GRIPPER = "ON"

--- a/src/libfranka.cpp
+++ b/src/libfranka.cpp
@@ -1,6 +1,5 @@
 #include <franka/control_tools.h>
 #include <franka/gripper.h>
-#include <franka/vacuum_gripper.h>
 #include <franka/model.h>
 #include <franka/rate_limiting.h>
 #include <franka/robot.h>
@@ -10,6 +9,10 @@
 #include <pybind11/stl.h>
 
 #include <sstream>
+
+#ifdef VACUUM_GRIPPER
+#include <franka/vacuum_gripper.h>
+#endif
 
 #define PYBIND11_DETAILED_ERROR_MESSAGES 1
 
@@ -451,6 +454,7 @@ PYBIND11_MODULE(libfranka, m) {
            py::call_guard<py::gil_scoped_release>())
       .def("read_once", &franka::Gripper::readOnce);
 
+#ifdef VACUUM_GRIPPER
   py::enum_<franka::VacuumGripperDeviceStatus>(m, "VacuumGripperDeviceStatus")
       .value("kGreen", franka::VacuumGripperDeviceStatus::kGreen)
       .value("kYellow", franka::VacuumGripperDeviceStatus::kYellow)
@@ -484,7 +488,8 @@ PYBIND11_MODULE(libfranka, m) {
       .def("stop", &franka::VacuumGripper::stop,
            py::call_guard<py::gil_scoped_release>())
       .def("read_once", &franka::VacuumGripper::readOnce);       
-  
+  #endif
+
   m.def("is_valid_elbow", &franka::isValidElbow, py::arg("elbow"));
   m.def("is_homogeneous_transformation", &franka::isHomogeneousTransformation,
         py::arg("transform"));


### PR DESCRIPTION
Old libfranka versions like 0.7.1 didn't support the vacuum gripper. This PR adds macros to make building support for the vacuum gripper optional.