### PR TITLE
Change lock/unlock API call based on platform type

### DIFF
--- a/src/panda_py/__init__.py
+++ b/src/panda_py/__init__.py
@@ -90,7 +90,7 @@ class Desk:
     self.login()
     self._legacy = False
 
-    if platform.lower() in ["panda", "fer"]:
+    if platform.lower() in ["panda", "fer", "franka_emika_robot", "frankaemikarobot"]:
       self._platform = "panda"
     elif platform.lower() in ["fr3", "frankaresearch3", "franka_research_3"]:
       self._platform = "fr3"

--- a/src/panda_py/__init__.py
+++ b/src/panda_py/__init__.py
@@ -113,7 +113,7 @@ class Desk:
     if self._platform == 'panda':
       url = '/desk/api/robot/close-brakes'
     elif self._platform == 'fr3':
-      url = '/desk/api/joint/lock'
+      url = '/desk/api/joints/lock'
 
     self._request('post',
                   url,
@@ -126,7 +126,7 @@ class Desk:
     if self._platform == 'panda':
       url = '/desk/api/robot/open-brakes'
     elif self._platform == 'fr3':
-      url = '/desk/api/joint/unlock'
+      url = '/desk/api/joints/unlock'
 
     self._request('post',
                   url,

--- a/src/panda_py/__init__.py
+++ b/src/panda_py/__init__.py
@@ -76,7 +76,7 @@ class Desk:
   robot's Pilot interface.
   """
 
-  def __init__(self, hostname: str, username: str, password: str, platform: str = "panda") -> None:
+  def __init__(self, hostname: str, username: str, password: str, platform: str = 'panda') -> None:
     urllib3.disable_warnings()
     self._session = requests.Session()
     self._session.verify = False
@@ -90,10 +90,10 @@ class Desk:
     self.login()
     self._legacy = False
 
-    if platform.lower() in ["panda", "fer", "franka_emika_robot", "frankaemikarobot"]:
-      self._platform = "panda"
-    elif platform.lower() in ["fr3", "frankaresearch3", "franka_research_3"]:
-      self._platform = "fr3"
+    if platform.lower() in ['panda', 'fer', 'franka_emika_robot', 'frankaemikarobot']:
+      self._platform = 'panda'
+    elif platform.lower() in ['fr3', 'frankaresearch3', 'franka_research_3']:
+      self._platform = 'fr3'
     else:
       raise ValueError("Unknown platform! Must be either 'panda' or 'fr3'!")
 
@@ -110,9 +110,9 @@ class Desk:
     """
     Locks the brakes. API call blocks until the brakes are locked.
     """
-    if self._platform == "panda":
+    if self._platform == 'panda':
       url = '/desk/api/robot/close-brakes'
-    elif self._platform == "fr3":
+    elif self._platform == 'fr3':
       url = '/desk/api/joint/lock'
 
     self._request('post',
@@ -123,9 +123,9 @@ class Desk:
     """
     Unlocks the brakes. API call blocks until the brakes are unlocked.
     """
-    if self._platform == "panda":
+    if self._platform == 'panda':
       url = '/desk/api/robot/open-brakes'
-    elif self._platform == "fr3":
+    elif self._platform == 'fr3':
       url = '/desk/api/joint/unlock'
 
     self._request('post',

--- a/src/panda_py/cli.py
+++ b/src/panda_py/cli.py
@@ -32,9 +32,10 @@ def unlock():
   parser.add_argument('host',  type=str, help='Robot Desk IP or hostname.')
   parser.add_argument('user', type=str, help='Desk username.')
   parser.add_argument('password', type=str, help='Desk password.')
+  parser.add_argument('platform', type=str, default='panda', help='Platform of robot.')
   args = parser.parse_args()
 
-  desk = Desk(args.host, args.user, args.password)
+  desk = Desk(args.host, args.user, args.password, platform=args.platform)
   desk.unlock()
   desk.activate_fci()
 
@@ -52,9 +53,10 @@ def lock():
   parser.add_argument('host',  type=str, help='Robot Desk IP or hostname.')
   parser.add_argument('user', type=str, help='Desk username.')
   parser.add_argument('password', type=str, help='Desk password.')
+  parser.add_argument('platform', type=str, default='panda', help='Platform of robot.')
   args = parser.parse_args()
 
-  desk = Desk(args.host, args.user, args.password)
+  desk = Desk(args.host, args.user, args.password, platform=args.platform)
   desk.lock()
   desk.deactivate_fci()
 
@@ -75,7 +77,8 @@ def reboot():
   parser.add_argument('host',  type=str, help='Robot Desk IP or hostname.')
   parser.add_argument('user', type=str, help='Desk username.')
   parser.add_argument('password', type=str, help='Desk password.')
+  parser.add_argument('platform', type=str, default='panda', help='Platform of robot.')
   args = parser.parse_args()
 
-  desk = Desk(args.host, args.user, args.password)
+  desk = Desk(args.host, args.user, args.password, platform=args.platform)
   desk.reboot()


### PR DESCRIPTION
This PR distinguishes between the Panda and the FR3 when initializing the `Desk` object, since the API calls seem to be different between platform type. Resolves #18.

New usage:
```
import panda_py
desk = panda_py.Desk(hostname, user, password, platform="fr3")  # or `platform="panda"`
desk.unlock()
```