### PR TITLE
chore: make cli platform argument optional

### DIFF
--- a/src/panda_py/cli.py
+++ b/src/panda_py/cli.py
@@ -16,6 +16,7 @@ executables and the corresponding entry-points.
 
 """
 import argparse
+
 from . import Desk
 
 
@@ -32,7 +33,7 @@ def unlock():
   parser.add_argument('host',  type=str, help='Robot Desk IP or hostname.')
   parser.add_argument('user', type=str, help='Desk username.')
   parser.add_argument('password', type=str, help='Desk password.')
-  parser.add_argument('platform', type=str, default='panda', help='Platform of robot.')
+  parser.add_argument('--platform', type=str, default='panda', help='Platform of robot.')
   args = parser.parse_args()
 
   desk = Desk(args.host, args.user, args.password, platform=args.platform)
@@ -53,7 +54,7 @@ def lock():
   parser.add_argument('host',  type=str, help='Robot Desk IP or hostname.')
   parser.add_argument('user', type=str, help='Desk username.')
   parser.add_argument('password', type=str, help='Desk password.')
-  parser.add_argument('platform', type=str, default='panda', help='Platform of robot.')
+  parser.add_argument('--platform', type=str, default='panda', help='Platform of robot.')
   args = parser.parse_args()
 
   desk = Desk(args.host, args.user, args.password, platform=args.platform)
@@ -77,7 +78,7 @@ def reboot():
   parser.add_argument('host',  type=str, help='Robot Desk IP or hostname.')
   parser.add_argument('user', type=str, help='Desk username.')
   parser.add_argument('password', type=str, help='Desk password.')
-  parser.add_argument('platform', type=str, default='panda', help='Platform of robot.')
+  parser.add_argument('--platform', type=str, default='panda', help='Platform of robot.')
   args = parser.parse_args()
 
   desk = Desk(args.host, args.user, args.password, platform=args.platform)


### PR DESCRIPTION
Needs to be not positional to apply the default value, otherwise this argument is not optional.