### PR TITLE
Detect the Desk brake endpoints instead of requiring a platform argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Releases before 1.0.0 are documented in the
 [GitHub releases](https://github.com/JeanElsner/panda-py/releases).
 
+## [Unreleased]
+
+### Changed
+
+- `Desk` now detects whether the robot serves the FER or the FR3 brake endpoints
+  instead of relying on the `platform` argument, which is now optional. The two
+  robots serve mutually exclusive endpoints and answer 404 for the other's
+  without touching the brakes, so `lock()` and `unlock()` retry on the other
+  endpoint and remember the result. Previously an FR3 user who did not pass
+  `platform="fr3"` got an HTML 404 page as an error message. The argument is
+  still honoured as a hint that avoids the extra request, and a mismatch between
+  it and the robot is logged as a warning.
+
 ## [1.0.0] - 2026-08-12
 
 Adds support for the libfranka versions used by current Franka Research 3 system

--- a/src/panda_py/__init__.py
+++ b/src/panda_py/__init__.py
@@ -84,10 +84,31 @@ class Desk:
     forcefully (cf. :py:func:`Desk.take_control`) but needs to confirm
     physical access to the robot by pressing the circle button on the
     robot's Pilot interface.
+
+    The FER and the FR3 serve mutually exclusive endpoints for the brakes.
+    Which one to use is detected on the first call to :py:func:`Desk.lock`
+    or :py:func:`Desk.unlock`, so the ``platform`` argument is optional.
     """
 
+    #: The brake endpoints, which differ between the FER and the FR3. Both
+    #: robots serve only their own pair and answer 404 for the other's.
+    _BRAKE_ENDPOINTS = {
+        "panda": {
+            "lock": "/desk/api/robot/close-brakes",
+            "unlock": "/desk/api/robot/open-brakes",
+        },
+        "fr3": {
+            "lock": "/desk/api/joints/lock",
+            "unlock": "/desk/api/joints/unlock",
+        },
+    }
+
     def __init__(
-        self, hostname: str, username: str, password: str, platform: str = "panda"
+        self,
+        hostname: str,
+        username: str,
+        password: str,
+        platform: typing.Optional[str] = None,
     ) -> None:
         urllib3.disable_warnings()
         self._session = requests.Session()
@@ -102,7 +123,12 @@ class Desk:
         self.login()
         self._legacy = False
 
-        if platform.lower() in [
+        # Only ever a hint about which brake endpoint to try first. Passing it
+        # saves a wasted request, but getting it wrong is recovered from.
+        self._platform_given = platform is not None
+        if platform is None:
+            self._platform = "panda"
+        elif platform.lower() in [
             "panda",
             "fer",
             "franka_emika_robot",
@@ -127,28 +153,84 @@ class Desk:
         """
         Locks the brakes. API call blocks until the brakes are locked.
         """
-        if self._platform == "panda":
-            url = "/desk/api/robot/close-brakes"
-        elif self._platform == "fr3":
-            url = "/desk/api/joints/lock"
-
-        self._request("post", url, files={"force": force})
+        self._brakes("lock", force)
 
     def unlock(self, force: bool = True) -> None:
         """
         Unlocks the brakes. API call blocks until the brakes are unlocked.
         """
-        if self._platform == "panda":
-            url = "/desk/api/robot/open-brakes"
-        elif self._platform == "fr3":
-            url = "/desk/api/joints/unlock"
+        self._brakes("unlock", force, headers={"X-Control-Token": self._token.token})
 
-        self._request(
-            "post",
-            url,
-            files={"force": force},
-            headers={"X-Control-Token": self._token.token},
+    def _brakes(
+        self,
+        action: typing.Literal["lock", "unlock"],
+        force: bool,
+        headers: typing.Dict[str, str] = None,
+    ) -> None:
+        """
+        Operates the brakes, discovering which endpoint this robot serves.
+
+        The FER and the FR3 each serve only their own pair of brake endpoints
+        and answer 404 for the other's, without touching the brakes. So the
+        platform can be detected by trying and retrying, which costs nothing
+        when the hint is right and needs no separate probe request.
+        """
+        candidates = [self._platform] + [
+            platform for platform in self._BRAKE_ENDPOINTS if platform != self._platform
+        ]
+        for platform in candidates:
+            response = self._request(
+                "post",
+                self._BRAKE_ENDPOINTS[platform][action],
+                files={"force": force},
+                headers=headers,
+                check=False,
+            )
+            if self._is_missing_endpoint(response):
+                continue
+            if not 200 <= response.status_code < 300:
+                raise ConnectionError(response.text)
+            self._detected_platform(platform)
+            return
+
+        raise ConnectionError(
+            f"This Desk serves neither the FER nor the FR3 endpoint to {action} the "
+            "brakes. The Desk API is undocumented and may have changed; please report "
+            "this at https://github.com/JeanElsner/panda-py/issues."
         )
+
+    @staticmethod
+    def _is_missing_endpoint(response: requests.Response) -> bool:
+        """
+        Whether a response means the endpoint does not exist on this robot.
+
+        The FR3 answers an unknown path with ``No handler accepted "<path>"``
+        and the FER with ``File not found``. Both come back as 404, but the
+        body is matched as well so that a firmware using another status code
+        for the same condition is still recognised.
+        """
+        return (
+            response.status_code == 404
+            or "no handler accepted" in (response.text or "").lower()
+        )
+
+    def _detected_platform(self, platform: str) -> None:
+        """
+        Records the platform a brake call succeeded on.
+        """
+        if platform == self._platform:
+            return
+        if self._platform_given:
+            _logger.warning(
+                "The Desk was created with platform=%r, but the robot serves the %r "
+                "brake endpoints. Using %r; drop the argument to detect it.",
+                self._platform,
+                platform,
+                platform,
+            )
+        else:
+            _logger.info("Detected platform %r from the brake endpoints.", platform)
+        self._platform = platform
 
     def reboot(self) -> None:
         """
@@ -349,6 +431,7 @@ class Desk:
         json: typing.Dict[str, str] = None,
         headers: typing.Dict[str, str] = None,
         files: typing.Dict[str, str] = None,
+        check: bool = True,
     ) -> requests.Response:
         fun = getattr(self._session, method)
         response: requests.Response = fun(
@@ -358,8 +441,9 @@ class Desk:
             files=files,
         )
         # Any 2xx is a success. Some endpoints, in particular the DELETE used to
-        # release a control token, answer 204 No Content.
-        if not 200 <= response.status_code < 300:
+        # release a control token, answer 204 No Content. Callers that inspect
+        # the failure themselves pass check=False.
+        if check and not 200 <= response.status_code < 300:
             raise ConnectionError(response.text)
         return response
 

--- a/src/panda_py/cli.py
+++ b/src/panda_py/cli.py
@@ -34,8 +34,8 @@ def _create_argument_parser(needs_platform: bool = True) -> argparse.ArgumentPar
         parser.add_argument(
             "--platform",
             type=str,
-            default="panda",
-            help="Platform of robot, i.e. panda (default) or fr3.",
+            default=None,
+            help="Robot platform, i.e. panda or fr3. Detected if omitted.",
         )
     return parser
 
@@ -49,6 +49,7 @@ def unlock():
       user: Username used to log into the Desk.
       password: Password of the given username.
       platform: The targeted robot platform, i.e. panda or fr3.
+        Detected from the robot if omitted.
     """
     parser = _create_argument_parser()
     args = parser.parse_args()
@@ -67,6 +68,7 @@ def lock():
       user: Username used to log into the Desk.
       password: Password of the given username.
       platform: The targeted robot platform, i.e. panda or fr3.
+        Detected from the robot if omitted.
     """
     parser = _create_argument_parser()
     args = parser.parse_args()

--- a/tests/test_desk.py
+++ b/tests/test_desk.py
@@ -1,5 +1,7 @@
 """The Desk client, exercised against a fake session rather than a robot."""
 
+import logging
+
 import pytest
 
 from panda_py import Desk, Token
@@ -16,15 +18,23 @@ class _Response:
 
 
 class _Session:
-    """Records the last request and returns a canned response."""
+    """Records the last request and returns a canned response.
 
-    def __init__(self, response):
+    A dict of url suffix to response makes a robot that serves only some of the
+    endpoints, which is how the FER and the FR3 differ.
+    """
+
+    def __init__(self, response, by_url=None):
         self._response = response
+        self._by_url = by_url or {}
         self.calls = []
 
     def _record(self, method):
         def call(url, json=None, headers=None, files=None):
             self.calls.append((method, url, json, headers, files))
+            for suffix, response in self._by_url.items():
+                if url.endswith(suffix):
+                    return response
             return self._response
 
         return call
@@ -35,15 +45,30 @@ class _Session:
         raise AttributeError(name)
 
 
-def _desk(response):
+def _desk(response, by_url=None, platform="panda", platform_given=True):
     """A Desk with the network replaced, bypassing the connecting constructor."""
     desk = Desk.__new__(Desk)
-    desk._session = _Session(response)
+    desk._session = _Session(response, by_url)
     desk._hostname = "robot.local"
     desk._legacy = False
-    desk._platform = "panda"
+    desk._platform = platform
+    desk._platform_given = platform_given
     desk._token = Token()
     return desk
+
+
+#: A robot that serves only the FR3 brake endpoints, i.e. answers 404 for the
+#: FER's, which is what an FR3 does to a client that assumes an FER.
+FR3_ONLY = {
+    "/desk/api/robot/open-brakes": _Response(404, text='No handler accepted "..."'),
+    "/desk/api/robot/close-brakes": _Response(404, text='No handler accepted "..."'),
+}
+
+#: A robot that serves only the FER brake endpoints.
+FER_ONLY = {
+    "/desk/api/joints/unlock": _Response(404, text="File not found"),
+    "/desk/api/joints/lock": _Response(404, text="File not found"),
+}
 
 
 @pytest.mark.parametrize("status", [200, 201, 204])
@@ -80,17 +105,82 @@ def test_encode_password_is_deterministic_and_text():
     assert Desk.encode_password("other", "secret") != first
 
 
-def test_platform_selects_the_brake_endpoints():
+@pytest.mark.parametrize(
+    "platform,action,expected",
+    [
+        ("panda", "unlock", "/desk/api/robot/open-brakes"),
+        ("panda", "lock", "/desk/api/robot/close-brakes"),
+        ("fr3", "unlock", "/desk/api/joints/unlock"),
+        ("fr3", "lock", "/desk/api/joints/lock"),
+    ],
+)
+def test_platform_hint_is_tried_first(platform, action, expected):
     """The FER and the FR3 expose different endpoints for the brakes."""
-    desk = _desk(_Response(200))
-    desk._platform = "panda"
-    desk.unlock()
-    assert desk._session.calls[-1][1].endswith("/desk/api/robot/open-brakes")
+    desk = _desk(_Response(200), platform=platform)
+    getattr(desk, action)()
+    assert len(desk._session.calls) == 1, "no fallback needed when the hint is right"
+    assert desk._session.calls[0][1].endswith(expected)
 
-    desk = _desk(_Response(200))
-    desk._platform = "fr3"
+
+@pytest.mark.parametrize("action", ["lock", "unlock"])
+@pytest.mark.parametrize(
+    "hint,serves,detected",
+    [("panda", FR3_ONLY, "fr3"), ("fr3", FER_ONLY, "panda")],
+)
+def test_wrong_platform_falls_back_to_the_other_endpoint(
+    action, hint, serves, detected
+):
+    """A 404 from the brake endpoint means the other generation's is the right one.
+
+    The wrong endpoint does not touch the brakes, so retrying is safe. Before
+    this, an FR3 user who did not pass platform='fr3' got a raw HTML 404.
+    """
+    desk = _desk(_Response(200), by_url=serves, platform=hint)
+    getattr(desk, action)()
+    urls = [call[1] for call in desk._session.calls]
+    assert len(urls) == 2, urls
+    assert urls[-1].endswith(Desk._BRAKE_ENDPOINTS[detected][action])
+    # The detection is remembered, so the next call goes straight there.
+    assert desk._platform == detected
+
+
+def test_detection_is_not_repeated():
+    desk = _desk(_Response(200), by_url=FR3_ONLY, platform="panda")
     desk.unlock()
-    assert desk._session.calls[-1][1].endswith("/desk/api/joints/unlock")
+    desk.unlock()
+    assert len(desk._session.calls) == 3, "one fallback, then straight to the FR3"
+
+
+def test_a_non_404_failure_is_raised_rather_than_retried():
+    """Only a missing endpoint justifies a retry; an auth failure must surface."""
+    desk = _desk(_Response(401, text="not in control"))
+    with pytest.raises(ConnectionError, match="not in control"):
+        desk.unlock()
+    assert len(desk._session.calls) == 1
+
+
+def test_brakes_raise_when_neither_endpoint_exists():
+    desk = _desk(_Response(404, text="File not found"))
+    with pytest.raises(ConnectionError, match="neither the FER nor the FR3"):
+        desk.unlock()
+
+
+def test_explicit_wrong_platform_warns(caplog):
+    """Silently correcting an explicit argument would hide a bad configuration."""
+    desk = _desk(_Response(200), by_url=FR3_ONLY, platform="panda")
+    with caplog.at_level(logging.INFO):
+        desk.unlock()
+    assert any(record.levelno == logging.WARNING for record in caplog.records)
+
+
+def test_detection_without_a_hint_only_logs_info(caplog):
+    desk = _desk(
+        _Response(200), by_url=FR3_ONLY, platform="panda", platform_given=False
+    )
+    with caplog.at_level(logging.INFO):
+        desk.unlock()
+    assert desk._platform == "fr3"
+    assert not any(record.levelno >= logging.WARNING for record in caplog.records)
 
 
 def test_legacy_desk_skips_control_tokens():


### PR DESCRIPTION
`Desk` requires the caller to declare which robot they have, because the FER and
the FR3 serve mutually exclusive endpoints for the brakes:

| Endpoint | FER | FR3 |
|---|:-:|:-:|
| `/desk/api/robot/open-brakes`, `close-brakes` | ✔ | — |
| `/desk/api/joints/unlock`, `lock` | — | ✔ |

Get it wrong and the robot answers 404, which `Desk` surfaces as a raw HTML error
page. The argument is a guess the caller has no way to check, and it defaults to
`panda`, so every FR3 user hits this once.

Because the wrong endpoint 404s *without touching the brakes*, retrying is safe.
`lock()` and `unlock()` now try one endpoint, fall back to the other on a
missing-endpoint response, and remember the result. Detection lives in the two
methods that actually differ, costs nothing when the hint is right, and needs no
separate probe request on connect.

### The platform argument is now optional, not deprecated

It stays as a hint that skips the extra request. No `DeprecationWarning`:
`platform="fr3"` is what the documentation currently tells people to write, there
is nothing better to migrate to, and since the Desk API is undocumented and
reverse-engineered, an explicit value is the escape hatch if a future firmware
changes the 404 signature.

- Unspecified tries `panda` first, so FER behaviour is unchanged and FR3 users
  pay one harmless 404 on their first brake call.
- An explicit value contradicted by the robot logs a **warning** — silently
  correcting it would hide a misconfiguration.
- Detection without a hint logs **info**.

### Notes

- `_request` gained `check: bool = True`. Existing callers and the
  `ConnectionError` contract are untouched; only `_brakes` inspects failures.
- Only a missing endpoint triggers the retry. A 401 from not holding the control
  token raises as before, rather than being retried against the other platform
  and reported with the wrong error.
- The response body is matched alongside the status code. Both robots return 404,
  but the FR3 says `No handler accepted "<path>"` and the FER `File not found`;
  matching the body means a firmware using a different status for the same
  condition still works.

### Testing

`tests/test_desk.py` goes from 8 to 23 tests, 56 across the suite, all passing.
The fake session takes a per-URL response map, so the fixtures are robots that
genuinely 404 the other generation's endpoints. Covered: a correct hint takes
exactly one request, both wrong-hint directions fall back and cache, detection is
not repeated, a 401 raises without retrying, neither-endpoint-present raises an
actionable error, and the warn-vs-info split.
