### PR TITLE
Stop the wheel builds racing the build-environment image push

### DIFF
--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -19,6 +19,13 @@ on:
       - ".github/workflows/build_images.yml"
   workflow_dispatch:
 
+# Shared with the wheel workflows, which pull the tags pushed here. Without
+# this they start on the same push and a wheel job can pull a tag mid-push,
+# which GHCR answers with "denied" and which fails the row.
+concurrency:
+  group: build-environment-images
+  cancel-in-progress: false
+
 permissions:
   contents: read
   packages: write

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,14 @@ on:
   push:
     branches: ["main"]
 
+# Shared with build_images.yml, which pushes the image tags the wheel jobs
+# below pull. A push that changes the Dockerfile or the build scripts starts
+# both workflows at once, and pulling a tag while it is being pushed fails the
+# row with "denied". Queue instead of cancelling so the wheels still get built.
+concurrency:
+  group: build-environment-images
+  cancel-in-progress: false
+
 jobs:
   build_wheels:
     name: Build wheels for libfranka ${{ matrix.libfranka-version }}


### PR DESCRIPTION
`build_images.yml` pushes `ghcr.io/jeanelsner/panda-py-build:<version>`, and the
wheel jobs in `main.yml` pull those exact tags. Both trigger on a push to `main`,
so a push that touches the `Dockerfile`, the build scripts or the patches starts
them **simultaneously** — and a wheel job can pull a tag while it is still being
pushed. GHCR answers that with `denied` and the row fails.

This is not hypothetical; it happened on b2c01e8, the Dependabot action bump,
which matched `build_images.yml`'s own path filter:

| | |
|---|---|
| `build_images.yml` pushing `0.17.0` | 15:51:19 → 15:51:**28** |
| `main.yml` pulling `0.17.0` → `denied: denied` | 15:51:**23** |

```
Error response from daemon: Head "https://ghcr.io/v2/jeanelsner/panda-py-build/manifests/0.17.0": denied: denied
##[error]cibuildwheel: Command ['docker', 'create', ..., '--pull=always', 'ghcr.io/jeanelsner/panda-py-build:0.17.0', ...] failed with code 1.
```

`fail-fast` then cancelled the other seven rows. Re-running afterwards passed,
because by then the push had finished — which is what makes this a race rather
than a broken bump. The images are public and pull anonymously.

A concurrency group shared between the two workflows serialises them, so the
wheels are always built against a fully pushed image. It queues rather than
cancels, since the point is to build the wheels, not to skip them. On pushes that
do not rebuild images there is nothing to queue behind, so it costs nothing.

### Deliberately not applied to the other two workflows

- **`release.yml`** triggers on a published release, not a push, so it cannot
  coincide with an image build. Putting a release run into a cancellable queue is
  a worse failure mode than the race it would prevent.
- **`pull_request.yml`** would be serialised against *every other pull request*,
  since a concurrency group is repo-wide. A PR run racing an image push is much
  rarer and a re-run fixes it.
